### PR TITLE
Added proper lumisection in GENSIM [ci skip]

### DIFF
--- a/Generator/GensimRunner.py
+++ b/Generator/GensimRunner.py
@@ -107,7 +107,7 @@ class GensimRunner:
                     indices = range(self.maxindex)
                 elif mode is 'resubmit':
                     print green('--> Now checking for missing files on T2 for generation step \'%s\' of job \'%s\'...' % (generation_step, jobname))
-                    indices = missing_indices = findMissingRootFiles(filepath=self.T2_director_root+self.T2_path+'/'+self.folderstructure[generation_step]['pathtag']+'/'+jobname, filename_base=self.folderstructure[generation_step]['outfilenamebase'], maxindex=self.maxindex, treename='Events')
+                    indices = missing_indices = findMissingRootFiles(filename_base=os.path.join(self.T2_director_root+self.T2_path,self.folderstructure[generation_step]['pathtag'], jobname, self.folderstructure[generation_step]['outfilenamebase']), maxindex=self.maxindex, treename='Events')
 
                 njobs = 0
                 for i in indices:

--- a/Generator/GensimRunner.py
+++ b/Generator/GensimRunner.py
@@ -118,7 +118,7 @@ class GensimRunner:
                         command = getcmsRunCommand(pset=self.folderstructure[generation_step]['pset'], infilename=infilename, outfilename=outfilename, N=-1, ncores=ncores)
                     else:
                         infilename   = self.gridpackfolder + '/' + processname + '/' + jobname + '_' + self.arch_tag + '_' + self.cmssw_tag_gp + '_tarball.tar.xz'
-                        command = getcmsRunCommand(pset=self.folderstructure[generation_step]['pset'], gridpack=infilename, outfilename=outfilename, N=self.nevents, ncores=ncores)
+                        command = getcmsRunCommand(pset=self.folderstructure[generation_step]['pset'], gridpack=infilename, outfilename=outfilename, N=self.nevents, ncores=ncores, lumiblock=i+1)
                     f.write(command + '\n')
                     njobs += 1
 
@@ -127,7 +127,7 @@ class GensimRunner:
                 if mode is 'new':        slurmjobname = '%s' % (self.folderstructure[generation_step]['jobnametag'])
                 elif mode is 'resubmit': slurmjobname = 'resubmit_%s' % (self.folderstructure[generation_step]['jobnametag'])
 
-                command = 'sbatch -a 1-%s -J %s -p %s -t %s --exclude t3wn[49,50,54,40,44,39] --cpus-per-task %i submit_cmsRun_command.sh %s %s %s %s %s' % (str(njobs), slurmjobname+'_'+jobname, queue, runtime_str, ncores, self.generatorfolder, self.arch_tag, self.workarea+'/'+self.folderstructure[generation_step]['cmsswtag'], self.T2_director+self.T2_path+'/'+self.folderstructure[generation_step]['pathtag']+'/'+jobname, commandfilename)
+                command = 'sbatch -a 1-%s -J %s -p %s -t %s --exclude t3wn[49,50,54,40,44,39] --cpus-per-task %i %s/submit_cmsRun_command.sh %s %s %s %s %s' % (str(njobs), slurmjobname+'_'+jobname, queue, runtime_str, ncores, self.generatorfolder, self.generatorfolder, self.arch_tag, self.workarea+'/'+self.folderstructure[generation_step]['cmsswtag'], self.T2_director+self.T2_path+'/'+self.folderstructure[generation_step]['pathtag']+'/'+jobname, commandfilename)
                 if njobs > 0:
                     if self.submit:
                         # print command

--- a/Generator/PSets/UL17/pset_01_gensim.py
+++ b/Generator/PSets/UL17/pset_01_gensim.py
@@ -14,6 +14,7 @@ gridpack    = ''
 outfilename = ''
 nevents     = -99
 nThreads    = -1
+lumiblock   = -1
 
 
 # USER OPTIONS
@@ -22,16 +23,18 @@ options.register('gridpack',    gridpack,    mytype=VarParsing.varType.string)
 options.register('outfilename', outfilename, mytype=VarParsing.varType.string)
 options.register('nevents',     nevents,     mytype=VarParsing.varType.int)
 options.register('nThreads',    nThreads,    mytype=VarParsing.varType.int)
+options.register('lumiblock',   lumiblock,   mytype=VarParsing.varType.int)
 options.parseArguments()
 gridpack    = os.path.abspath(options.gridpack)
 nevents     = options.nevents
 nThreads    = options.nThreads
+lumiblock   = options.lumiblock
 outfilename = 'file:' + os.path.abspath(options.outfilename)
 outfile_LHE = outfilename.replace('.root', '_LHE.root')
 
 
-if gridpack is '' or outfilename is '' or nevents is -99 or nThreads is -1:
-    raise ValueError('At least one of the 4 mandatory options is not set, please give all 4 options.')
+if gridpack is '' or outfilename is '' or nevents is -99 or nThreads is -1 or lumiblock is -1:
+    raise ValueError('At least one of the 5 mandatory options is not set, please give all 5 options.')
 
 
 print ">>> gridpack    = '%s'"%gridpack
@@ -39,6 +42,7 @@ print ">>> nevents     = %s"%nevents
 print ">>> nThreads    = %s"%nThreads
 print ">>> outfilename = '%s'"%outfilename
 print ">>> outfile_LHE = '%s'"%outfile_LHE
+print ">>> lumiblock    = %s"%lumiblock
 
 
 
@@ -63,7 +67,9 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 # Input source
-process.source = cms.Source("EmptySource")
+process.source = cms.Source("EmptySource",
+    firstLuminosityBlock = cms.untracked.uint32(lumiblock)
+)
 
 process.options = cms.untracked.PSet(
 

--- a/Generator/functions.py
+++ b/Generator/functions.py
@@ -275,11 +275,11 @@ def count_genevents_in_file(filename, treename='Events'):
 
 
 
-def getcmsRunCommand(pset, outfilename, N, ncores, infilename=None, gridpack=None):
+def getcmsRunCommand(pset, outfilename, N, ncores, infilename=None, gridpack=None, lumiblock=None):
     """Submit PSet config file and gridpack to SLURM batch system."""
 
-    if gridpack is not None and infilename is None:
-        command = 'cmsRun %s gridpack=%s outfilename=%s nevents=%i nThreads=%i' % (pset, gridpack, outfilename, N, ncores)
-    elif infilename is not None and gridpack is None:
+    if gridpack is not None and infilename is None and lumiblock is not None:
+        command = 'cmsRun %s gridpack=%s outfilename=%s nevents=%i nThreads=%i lumiblock=%i' % (pset, gridpack, outfilename, N, ncores, lumiblock)
+    elif infilename is not None and gridpack is None and lumiblock is None:
         command = 'cmsRun %s infilename=%s outfilename=%s nevents=%i nThreads=%i' % (pset, infilename, outfilename, N, ncores)
     return command


### PR DESCRIPTION
- now storing a unique combination of `lumiblock` and `number` (of the event) when running GENSIM privately. Before, the lumiblock was always 1, making it impossible to uniquely identify an event from private samples. However, this is now necessary for the flexible event content paradigm.

Addresses #22 