### PR TITLE
Move to two gen particle collections

### DIFF
--- a/Analyzer/include/ElectronHists.h
+++ b/Analyzer/include/ElectronHists.h
@@ -15,7 +15,7 @@ class ElectronHists : public BaseHists{
 
 public:
   // Constructors, destructor
-  ElectronHists(TString dir_);
+  ElectronHists(TString dir_, bool do_allgenparticles_ = false);
   ElectronHists(const ElectronHists &) = default;
   ElectronHists & operator = (const ElectronHists &) = default;
   ~ElectronHists() = default;
@@ -25,6 +25,8 @@ public:
 
 
 protected:
+  bool do_allgenparticles;
+  vector<GenParticle>* genparticles;
 
   shared_ptr<TH1D> hnelectrons, helectronpt, helectronpt_rebin, helectronpt_rebin2, helectroneta, helectronphi, helectronmass, helectronenergy, helectronpfiso, helectrondxy, helectrondz, helectrond, helectrongendrmin,
 

--- a/Analyzer/include/GenEvent.h
+++ b/Analyzer/include/GenEvent.h
@@ -21,43 +21,50 @@ public:
   GenEvent(){
     genmet                   = new Met;
     GenParticle p;
-    genparticles_visibletaus = new vector<GenParticle>;
+    genparticles_fromHP      = new vector<GenParticle>;
     genparticles_all         = new vector<GenParticle>;
+    genparticles_visibletaus = new vector<GenParticle>;
     genjets                  = new vector<GenJet>;
   }
   ~GenEvent(){
     delete genmet;
-    delete genparticles_visibletaus;
+    delete genparticles_fromHP;
     delete genparticles_all;
+    delete genparticles_visibletaus;
     delete genjets;
   };
 
   void clear(){
     Event::clear();
     delete genmet;
-    delete genparticles_visibletaus;
+    delete genparticles_fromHP;
     delete genparticles_all;
+    delete genparticles_visibletaus;
     delete genjets;
     genmet = 0;
-    genparticles_visibletaus = 0;
+    genparticles_fromHP = 0;
     genparticles_all = 0;
+    genparticles_visibletaus = 0;
     genjets = 0;
   }
   void reset(){
     Event::reset();
     delete genmet;
-    delete genparticles_visibletaus;
+    delete genparticles_fromHP;
     delete genparticles_all;
+    delete genparticles_visibletaus;
     delete genjets;
     GenParticle p;
     genmet                   = new Met;
-    genparticles_visibletaus = new vector<GenParticle>;
+    genparticles_fromHP      = new vector<GenParticle>;
     genparticles_all         = new vector<GenParticle>;
+    genparticles_visibletaus = new vector<GenParticle>;
     genjets                  = new vector<GenJet>;
   }
 
   Met* genmet;
-  vector<GenParticle>* genparticles_visibletaus;
+  vector<GenParticle>* genparticles_fromHP;
   vector<GenParticle>* genparticles_all;
+  vector<GenParticle>* genparticles_visibletaus;
   vector<GenJet>* genjets;
 };

--- a/Analyzer/include/GenParticleHists.h
+++ b/Analyzer/include/GenParticleHists.h
@@ -16,7 +16,7 @@ class GenParticleHists : public BaseHists{
 
 public:
   // Constructors, destructor
-  GenParticleHists(TString dir_);
+  GenParticleHists(TString dir_, bool do_allgenparticles_ = false);
   GenParticleHists(const GenParticleHists &) = default;
   GenParticleHists & operator = (const GenParticleHists &) = default;
   ~GenParticleHists() = default;
@@ -26,6 +26,9 @@ public:
 
 
 protected:
+
+  bool do_allgenparticles;
+  vector<GenParticle>* genparticles;
 
   shared_ptr<TH1D> hngentaus, hptgentau1, hptgentau1_rebin, hptgentau1_rebin2, hptgentau1_rebin3, hptgentau1_rebin4, hptgentau2, hptgentau2_rebin, hptgentau2_rebin2, hptgentau2_rebin3, hptgentau2_rebin4, hdrgenditau, hdphigenditau, hdetagenditau, hdrgentaumu, hdphigentaumu, hdetagentaumu, hdptgentaumu, hdptrelgentaumu, hdrgentaue, hdphigentaue, hdetagentaue, hdptgentaue, hdptrelgentaue,
 
@@ -39,10 +42,5 @@ protected:
 
   hngennus, hptgennu, hptgennu_rebin, hptgennu_rebin2, hphigennu, hetagennu, hdrminnue, hdrminnumu, hdrminnutau, hdphiminnue, hdphiminnumu, hdphiminnutau, hdetaminnue, hdetaminnumu, hdetaminnutau,
   hptgennu1, hptgennu1_rebin, hptgennu1_rebin2, hphigennu1, hetagennu1, hdrminnu1e, hdrminnu1mu, hdrminnu1tau, hdphiminnu1e, hdphiminnu1mu, hdphiminnu1tau, hdetaminnu1e, hdetaminnu1mu, hdetaminnu1tau;
-
-
-
-
-
 
 };

--- a/Analyzer/include/GenParticlePrinter.h
+++ b/Analyzer/include/GenParticlePrinter.h
@@ -8,8 +8,12 @@
 // #include <pair>
 
 class GenParticlePrinter: public AnalysisModule<RecoEvent>{
- public:
-  explicit GenParticlePrinter(const Config & cfg);
+public:
+  explicit GenParticlePrinter(const Config & cfg, bool do_allgenparticles_ = false);
   virtual bool process(RecoEvent & event) override;
+
+protected:
+  bool do_allgenparticles;
+  vector<GenParticle>* genparticles;
 
 };

--- a/Analyzer/include/MuonHists.h
+++ b/Analyzer/include/MuonHists.h
@@ -15,7 +15,7 @@ class MuonHists : public BaseHists{
 
 public:
   // Constructors, destructor
-  MuonHists(TString dir_);
+  MuonHists(TString dir_, bool do_allgenparticles_ = false);
   MuonHists(const MuonHists &) = default;
   MuonHists & operator = (const MuonHists &) = default;
   ~MuonHists() = default;
@@ -26,6 +26,8 @@ public:
 
 protected:
 
+  bool do_allgenparticles;
+  vector<GenParticle>* genparticles;
   shared_ptr<TH1D> hnmuons, hmuonpt, hmuonpt_rebin, hmuonpt_rebin2, hmuoneta, hmuonphi, hmuonmass, hmuonenergy, hmuonpfiso, hmuondxy, hmuondz, hmuond, hmuongendrmin, hmuongenflav,
 
   hmuonclosestd,

--- a/Analyzer/python/ntuplizer_cfg.py
+++ b/Analyzer/python/ntuplizer_cfg.py
@@ -122,7 +122,7 @@ process.ntuplizer = cms.EDFilter('NTuplizer',
     met               = cms.InputTag('slimmedMETs'),
     pileup            = cms.InputTag('slimmedAddPileupInfo'),
     genjets           = cms.InputTag('slimmedGenJets'),
-    genparticles      = cms.InputTag('prunedGenParticles'),
+    genparticles_pruned = cms.InputTag('prunedGenParticles'),
     geninfo           = cms.InputTag('generator'),
     lhe               = cms.InputTag('externalLHEProducer'),
 

--- a/Analyzer/python/ntuplizer_cfg.py
+++ b/Analyzer/python/ntuplizer_cfg.py
@@ -5,7 +5,7 @@ from FWCore.ParameterSet.VarParsing import VarParsing
 import os
 
 # Example to run:
-# cmsRun $ANALYZERPATH/python/ntuplizer_cfg.py type=MC infilename=root://cms-xrd-global.cern.ch//store/mc/RunIISummer20UL18MiniAODv2/GluGluHToZZTo4L_M125_TuneCP5_13TeV_powheg2_JHUGenV7011_pythia8/MINIAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/00000/D1F6F7C6-58B6-8142-9A44-D17FBB1C4F40.root outfilename=NTuples_pfonly.root idxStart=0 idxStop=100 year=UL18 standard=True pfcands=False triggerobjects=False
+# cmsRun $ANALYZERPATH/python/ntuplizer_cfg.py type=MC infilename=root://cms-xrd-global.cern.ch//store/mc/RunIISummer20UL18MiniAODv2/GluGluHToZZTo4L_M125_TuneCP5_13TeV_powheg2_JHUGenV7011_pythia8/MINIAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/00000/D1F6F7C6-58B6-8142-9A44-D17FBB1C4F40.root outfilename=NTuples_pfonly.root idxStart=0 idxStop=100 year=UL18 standard=True pfcands=False triggerobjects=False allgenparticles=False
 
 # USER OPTIONS
 options = VarParsing()
@@ -19,6 +19,7 @@ options.register('standard',       'False', mytype=VarParsing.varType.string)
 options.register('pfcands',        'False', mytype=VarParsing.varType.string)
 options.register('triggerobjects', 'False', mytype=VarParsing.varType.string)
 options.register('extrajets',      'False', mytype=VarParsing.varType.string)
+options.register('allgenparticles','False', mytype=VarParsing.varType.string)
 options.parseArguments()
 
 idx_start   = options.idxStart
@@ -31,6 +32,7 @@ do_standard_event = options.standard.lower() == 'true'
 do_pfcands  = options.pfcands.lower() == 'true'
 do_triggerobjects = options.triggerobjects.lower() == 'true'
 do_extrajets = options.extrajets.lower() == 'true'
+do_allgenparticles = options.allgenparticles.lower() == 'true'
 
 if idx_start < 0 or idx_stop < 1 or type is '' or year is '' or infilename is '' or outfilename is '':
     raise ValueError('At least one of the 6 required options is not set properly, please give all 6 options.')
@@ -38,7 +40,7 @@ if not type in ['DATA', 'MC']:
     raise ValueError('Invalid value for argument \'type\': %s. Can be \'MC\' or \'DATA\'.' % (type))
 if not idx_start < idx_stop:
     raise ValueError('Invalid value for arguments \'idx-start\' and \'idx-stop\': %i and %i. The stop index must be greater than the start index.' % (idx_start, idx_stop))
-if not (do_standard_event or do_pfcands or do_triggerobjects or do_extrajets):
+if not (do_standard_event or do_pfcands or do_triggerobjects or do_extrajets or do_allgenparticles):
    raise AttributeError('None of the collections is being requested, this sample would be empty! Is this a bug?')
 
 do_ak4chs = do_standard_event
@@ -52,7 +54,8 @@ print '-->  year         = %s'     % year
 print '-->  infilename   = \'%s\'' % infilename
 print '-->  outfilename  = \'%s\'' % outfilename
 print '-->  do_standard_event  = \'%s\'' % do_standard_event
-print '-->  do_triggerobjects = \'%s\'' % do_triggerobjects
+print '-->  do_triggerobjects  = \'%s\'' % do_triggerobjects
+print '-->  do_allgenparticles = \'%s\'' % do_allgenparticles
 print '-->  do_pfcands   = \'%s\'' % do_pfcands
 print '-->  do_ak4chs    = \'%s\'' % do_ak4chs
 print '-->  do_ak4puppi  = \'%s\'' % do_ak4puppi
@@ -123,12 +126,14 @@ process.ntuplizer = cms.EDFilter('NTuplizer',
     pileup            = cms.InputTag('slimmedAddPileupInfo'),
     genjets           = cms.InputTag('slimmedGenJets'),
     genparticles_pruned = cms.InputTag('prunedGenParticles'),
+    genparticles      = cms.InputTag('packedGenParticles'),
     geninfo           = cms.InputTag('generator'),
     lhe               = cms.InputTag('externalLHEProducer'),
 
     do_standard_event = cms.bool(do_standard_event),
     do_triggerobjects = cms.bool(do_triggerobjects),
     do_pfcands        = cms.bool(do_pfcands),
+    do_allgenparticles = cms.bool(do_allgenparticles),
     do_prefiring      = cms.bool(not year in ['2018', 'UL18']),
     do_ak4chs         = cms.bool(do_ak4chs),
     do_ak4puppi       = cms.bool(do_ak4puppi),

--- a/Analyzer/src/ElectronHists.cc
+++ b/Analyzer/src/ElectronHists.cc
@@ -18,7 +18,7 @@
 
 using namespace std;
 
-ElectronHists::ElectronHists(TString dir_) : BaseHists(dir_){
+ElectronHists::ElectronHists(TString dir_, bool do_allgenparticles_) : BaseHists(dir_), do_allgenparticles(do_allgenparticles_){
 
   hnelectrons = book<TH1D>("nelectrons", ";N_{e}; Events / bin", 11, -0.5, 10.5);
   helectronpt = book<TH1D>("electronpt", ";p_{T}^{e} [GeV]; Events / bin", 50, 0, 1500);
@@ -92,6 +92,8 @@ ElectronHists::ElectronHists(TString dir_) : BaseHists(dir_){
 void ElectronHists::fill(const RecoEvent & event){
   double weight = event.weight;
 
+  if (do_allgenparticles) genparticles = event.genparticles_all;
+  else genparticles = event.genparticles_fromHP;
 
 
   // Loop through jets
@@ -102,7 +104,7 @@ void ElectronHists::fill(const RecoEvent & event){
   for(size_t i=0; i<nelectrons; i++){
     Electron e = event.electrons->at(i);
     float gendr_min = 99999.;
-    for(const auto & gp : *event.genparticles_all){
+    for(const auto & gp : *genparticles){
       if(abs(gp.pdgid()) != 11) continue;
       if(!gp.isLastCopy()) continue;
       float dr = deltaR(e, gp);

--- a/Analyzer/src/GenParticlePrinter.cc
+++ b/Analyzer/src/GenParticlePrinter.cc
@@ -6,10 +6,13 @@
 using namespace std;
 
 
-GenParticlePrinter::GenParticlePrinter(const Config & cfg){}
+GenParticlePrinter::GenParticlePrinter(const Config & cfg,bool do_allgenparticles_): do_allgenparticles(do_allgenparticles_) {}
 
 bool GenParticlePrinter::process(RecoEvent & event){
   if(event.is_data) return false;
+
+  if (do_allgenparticles) genparticles = event.genparticles_all;
+  else genparticles = event.genparticles_fromHP;
 
   cout << "     +=====================+" << endl;
   cout << "     |     GenParticles    |" << endl;
@@ -18,21 +21,21 @@ bool GenParticlePrinter::process(RecoEvent & event){
   cout << "Number, Identifier, pdgId, mother, pt, eta" << endl;
   cout << "------------------------------------------" << endl;
 
-  for(size_t i=0; i<event.genparticles_all->size(); i++){
+  for(size_t i=0; i<genparticles->size(); i++){
     int correct_idx = -1;
-    for(size_t j=0; j<event.genparticles_all->size(); j++){
-      if(event.genparticles_all->at(j).identifier() == (int)i){
+    for(size_t j=0; j<genparticles->size(); j++){
+      if(genparticles->at(j).identifier() == (int)i){
         correct_idx = j;
         break;
       }
     }
-    GenParticle gp = event.genparticles_all->at(correct_idx);
+    GenParticle gp = genparticles->at(correct_idx);
 
     // now find mother using the identifier again
     int motherpdgid = -1;
-    for(size_t j=0; j<event.genparticles_all->size(); j++){
-      if(event.genparticles_all->at(j).identifier() == gp.mother_identifier()){
-        motherpdgid = event.genparticles_all->at(j).pdgid();
+    for(size_t j=0; j<genparticles->size(); j++){
+      if(genparticles->at(j).identifier() == gp.mother_identifier()){
+        motherpdgid = genparticles->at(j).pdgid();
         break;
       }
     }

--- a/Analyzer/src/MuonHists.cc
+++ b/Analyzer/src/MuonHists.cc
@@ -18,7 +18,7 @@
 
 using namespace std;
 
-MuonHists::MuonHists(TString dir_) : BaseHists(dir_){
+MuonHists::MuonHists(TString dir_, bool do_allgenparticles_) : BaseHists(dir_), do_allgenparticles(do_allgenparticles_){
 
   hnmuons = book<TH1D>("nmuons", ";N_{#mu}; Events / bin", 11, -0.5, 10.5);
   hmuonpt = book<TH1D>("muonpt", ";p_{T}^{#mu} [GeV]; Events / bin", 50, 0, 1500);
@@ -99,7 +99,8 @@ MuonHists::MuonHists(TString dir_) : BaseHists(dir_){
 void MuonHists::fill(const RecoEvent & event){
   double weight = event.weight;
 
-
+  if (do_allgenparticles) genparticles = event.genparticles_all;
+  else genparticles = event.genparticles_fromHP;
 
   // Loop through muons
   // ====================
@@ -111,7 +112,7 @@ void MuonHists::fill(const RecoEvent & event){
   for(size_t i=0; i<nmuons; i++){
     Muon m = event.muons->at(i);
     float gendr_min = 99999.;
-    for(const auto & gp : *event.genparticles_all){
+    for(const auto & gp : *genparticles){
       if(abs(gp.pdgid()) != 13) continue;
       if(!gp.isLastCopy()) continue;
       float dr = deltaR(m, gp);


### PR DESCRIPTION
Two gen particle collections implemented. This will save ~20% in event size.
GenParticles from HardProcess (both isHardProcess and fromHardProcess) are stored by default.
Gave default to modules using genparticles_al