### PR TITLE
Updating parallel processing

### DIFF
--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120.xml
@@ -1,4 +1,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120/NTuples_MINIAOD_1.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120/NTuples_MINIAOD_13.root"/>
@@ -14,6 +15,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120/NTuples_MINIAOD_8.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M120/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 1000000 -->
-<!-- Generated number of events: 910000.0 -->
-<!-- Weighted number of events: 28226096.5368 -->
+<!-- Generated number of events: 1000000.0 -->
+<!-- Weighted number of events: 31017227.6888 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124.xml
@@ -18,11 +18,12 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_3.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 989000 -->
-<!-- Generated number of events: 925000.0 -->
-<!-- Weighted number of events: 27091870.3462 -->
+<!-- Generated number of events: 989000.0 -->
+<!-- Weighted number of events: 28965270.4862 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125.xml
@@ -12,6 +12,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_2.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_20.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_21.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_24.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_25.root"/>
@@ -24,5 +25,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 498000 -->
-<!-- Generated number of events: 488000.0 -->
-<!-- Weighted number of events: 1920382.34436 -->
+<!-- Generated number of events: 498000.0 -->
+<!-- Weighted number of events: 1959725.49446 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130.xml
@@ -14,6 +14,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_21.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_23.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_24.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_27.root"/>

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120.xml
@@ -17,5 +17,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 1000000 -->
-<!-- Generated number of events: 971490.0 -->
-<!-- Weighted number of events: 30132545.2388 -->
+<!-- Generated number of events: 1000000.0 -->
+<!-- Weighted number of events: 31017227.6888 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120.xml
@@ -1,4 +1,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_1.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_13.root"/>
@@ -14,6 +15,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_8.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M120/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 1000000 -->
-<!-- Generated number of events: 910000.0 -->
-<!-- Weighted number of events: 28226096.5368 -->
+<!-- Generated number of events: 971490.0 -->
+<!-- Weighted number of events: 30132545.2388 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124.xml
@@ -18,11 +18,12 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_3.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 989000 -->
-<!-- Generated number of events: 925000.0 -->
-<!-- Weighted number of events: 27091870.3462 -->
+<!-- Generated number of events: 989000.0 -->
+<!-- Weighted number of events: 28965270.4862 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125.xml
@@ -12,6 +12,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_2.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_20.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_21.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_24.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_25.root"/>
@@ -24,5 +25,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 498000 -->
-<!-- Generated number of events: 488000.0 -->
-<!-- Weighted number of events: 1920382.34436 -->
+<!-- Generated number of events: 498000.0 -->
+<!-- Weighted number of events: 1959725.49446 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130.xml
@@ -14,6 +14,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_21.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_23.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_24.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_27.root"/>

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120.xml
@@ -1,4 +1,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120/NTuples_MINIAOD_1.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120/NTuples_MINIAOD_13.root"/>
@@ -14,6 +15,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120/NTuples_MINIAOD_8.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M120/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 1000000 -->
-<!-- Generated number of events: 910000.0 -->
-<!-- Weighted number of events: 28226096.5368 -->
+<!-- Generated number of events: 1000000.0 -->
+<!-- Weighted number of events: 31017227.6888 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124.xml
@@ -18,11 +18,12 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_3.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 989000 -->
-<!-- Generated number of events: 925000.0 -->
-<!-- Weighted number of events: 27091870.3462 -->
+<!-- Generated number of events: 989000.0 -->
+<!-- Weighted number of events: 28965270.4862 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125.xml
@@ -12,6 +12,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_2.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_20.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_21.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_24.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_25.root"/>
@@ -24,5 +25,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 498000 -->
-<!-- Generated number of events: 488000.0 -->
-<!-- Weighted number of events: 1920382.34436 -->
+<!-- Generated number of events: 498000.0 -->
+<!-- Weighted number of events: 1959725.49446 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130.xml
@@ -14,6 +14,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_21.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_23.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_24.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_27.root"/>

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120.xml
@@ -1,4 +1,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_1.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_13.root"/>
@@ -16,5 +17,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 1000000 -->
-<!-- Generated number of events: 939000.0 -->
-<!-- Weighted number of events: 29126198.5688 -->
+<!-- Generated number of events: 1000000.0 -->
+<!-- Weighted number of events: 31017227.6888 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120.xml
@@ -14,6 +14,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_8.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M120/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 1000000 -->
-<!-- Generated number of events: 910000.0 -->
-<!-- Weighted number of events: 28226096.5368 -->
+<!-- Generated number of events: 939000.0 -->
+<!-- Weighted number of events: 29126198.5688 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124.xml
@@ -18,11 +18,12 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_3.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 989000 -->
-<!-- Generated number of events: 925000.0 -->
-<!-- Weighted number of events: 27091870.3462 -->
+<!-- Generated number of events: 989000.0 -->
+<!-- Weighted number of events: 28965270.4862 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125.xml
@@ -25,5 +25,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 498000 -->
-<!-- Generated number of events: 493400.0 -->
-<!-- Weighted number of events: 1941638.04866 -->
+<!-- Generated number of events: 498000.0 -->
+<!-- Weighted number of events: 1959725.49446 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125.xml
@@ -12,6 +12,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_2.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_20.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_21.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_24.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_25.root"/>
@@ -24,5 +25,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 498000 -->
-<!-- Generated number of events: 488000.0 -->
-<!-- Weighted number of events: 1920382.34436 -->
+<!-- Generated number of events: 493400.0 -->
+<!-- Weighted number of events: 1941638.04866 -->

--- a/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130.xml
@@ -14,6 +14,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_21.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_23.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_24.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL16postVFP/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_27.root"/>

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126.xml
@@ -1,7 +1,10 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_1.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_10.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_12.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_14.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_15.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_16.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_17.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_18.root"/>
@@ -10,11 +13,14 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_20.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_21.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_22.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_3.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_4.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 724000.0 -->
-<!-- Weighted number of events: 20618773.0426 -->
+<!-- Generated number of events: 994000.0 -->
+<!-- Weighted number of events: 28306472.6556 -->

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125.xml
@@ -1,6 +1,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_1.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_11.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_14.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_15.root"/>
@@ -13,7 +14,8 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_7.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M125/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 499000 -->
-<!-- Generated number of events: 482000.0 -->
-<!-- Weighted number of events: 1896675.5744 -->
+<!-- Generated number of events: 499000.0 -->
+<!-- Weighted number of events: 1963555.777 -->

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126.xml
@@ -1,6 +1,8 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_1.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_10.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_12.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_14.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_16.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_17.root"/>
@@ -10,11 +12,14 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_20.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_21.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_22.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_3.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_4.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 724000.0 -->
-<!-- Weighted number of events: 20618773.0426 -->
+<!-- Generated number of events: 801100.0 -->
+<!-- Weighted number of events: 23863065.2606 -->

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126.xml
@@ -4,6 +4,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_14.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_15.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_16.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_17.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_18.root"/>
@@ -21,5 +22,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 801100.0 -->
-<!-- Weighted number of events: 23863065.2606 -->
+<!-- Generated number of events: 994000.0 -->
+<!-- Weighted number of events: 28306472.6556 -->

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125.xml
@@ -1,6 +1,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_1.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_11.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_14.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_15.root"/>
@@ -13,7 +14,8 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_7.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M125/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 499000 -->
-<!-- Generated number of events: 482000.0 -->
-<!-- Weighted number of events: 1896675.5744 -->
+<!-- Generated number of events: 499000.0 -->
+<!-- Weighted number of events: 1963555.777 -->

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126.xml
@@ -1,7 +1,10 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_1.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_10.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_12.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_14.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_15.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_16.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_17.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_18.root"/>
@@ -10,11 +13,14 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_20.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_21.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_22.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_3.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_4.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 724000.0 -->
-<!-- Weighted number of events: 20618773.0426 -->
+<!-- Generated number of events: 994000.0 -->
+<!-- Weighted number of events: 28306472.6556 -->

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125.xml
@@ -1,6 +1,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_1.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_11.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_14.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_15.root"/>
@@ -13,7 +14,8 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_7.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M125/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 499000 -->
-<!-- Generated number of events: 482000.0 -->
-<!-- Weighted number of events: 1896675.5744 -->
+<!-- Generated number of events: 499000.0 -->
+<!-- Weighted number of events: 1963555.777 -->

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126.xml
@@ -22,5 +22,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 952200.0 -->
-<!-- Weighted number of events: 27116219.7896 -->
+<!-- Generated number of events: 994000.0 -->
+<!-- Weighted number of events: 28306472.6556 -->

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126.xml
@@ -1,7 +1,10 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_1.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_10.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_12.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_14.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_15.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_16.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_17.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_18.root"/>
@@ -10,11 +13,14 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_20.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_21.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_22.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_3.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_4.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 724000.0 -->
-<!-- Weighted number of events: 20618773.0426 -->
+<!-- Generated number of events: 952200.0 -->
+<!-- Weighted number of events: 27116219.7896 -->

--- a/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125.xml
+++ b/Analyzer/datasets/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125.xml
@@ -1,6 +1,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_1.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_11.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_14.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_15.root"/>
@@ -13,7 +14,8 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_7.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL17/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M125/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 499000 -->
-<!-- Generated number of events: 482000.0 -->
-<!-- Weighted number of events: 1896675.5744 -->
+<!-- Generated number of events: 499000.0 -->
+<!-- Weighted number of events: 1963555.777 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124.xml
@@ -30,6 +30,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_36.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_37.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_38.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_39.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_6.root"/>
@@ -37,5 +38,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M124/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 945000.0 -->
-<!-- Weighted number of events: 27672092.9776 -->
+<!-- Generated number of events: 994000.0 -->
+<!-- Weighted number of events: 29107175.0076 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126.xml
@@ -1,4 +1,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_1.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_13.root"/>
@@ -14,11 +15,14 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_24.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_26.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_27.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_28.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_29.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_3.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_30.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_31.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_32.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_33.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_34.root"/>
@@ -29,5 +33,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 957000 -->
-<!-- Generated number of events: 843000.0 -->
-<!-- Weighted number of events: 24006991.3054 -->
+<!-- Generated number of events: 957000.0 -->
+<!-- Weighted number of events: 27253642.9674 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130.xml
@@ -4,7 +4,9 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_14.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_15.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_16.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_17.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_18.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_19.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_2.root"/>
@@ -24,15 +26,17 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_32.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_33.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_34.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_35.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_36.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_37.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_38.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_39.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/GluGluHToZZTo4L_M130/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 992000 -->
-<!-- Generated number of events: 776000.0 -->
-<!-- Weighted number of events: 20914857.0276 -->
+<!-- Generated number of events: 992000.0 -->
+<!-- Weighted number of events: 26737018.1176 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130.xml
@@ -20,6 +20,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_27.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_28.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_29.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_3.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/extrajets/VBF_HToZZTo4L_M130/NTuples_MINIAOD_6.root"/>

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124.xml
@@ -30,6 +30,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_36.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_37.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_38.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_39.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_6.root"/>
@@ -37,5 +38,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 945000.0 -->
-<!-- Weighted number of events: 27672092.9776 -->
+<!-- Generated number of events: 970300.0 -->
+<!-- Weighted number of events: 28413215.7066 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124.xml
@@ -38,5 +38,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M124/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 970300.0 -->
-<!-- Weighted number of events: 28413215.7066 -->
+<!-- Generated number of events: 994000.0 -->
+<!-- Weighted number of events: 29107175.0076 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126.xml
@@ -1,4 +1,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_1.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_13.root"/>
@@ -14,12 +15,14 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_24.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_27.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_28.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_29.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_3.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_30.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_31.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_32.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_33.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_34.root"/>
@@ -30,5 +33,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 957000 -->
-<!-- Generated number of events: 892000.0 -->
-<!-- Weighted number of events: 25403551.6054 -->
+<!-- Generated number of events: 957000.0 -->
+<!-- Weighted number of events: 27253642.9674 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130.xml
@@ -4,7 +4,9 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_14.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_15.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_16.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_17.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_18.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_19.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_2.root"/>
@@ -24,15 +26,17 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_32.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_33.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_34.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_35.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_36.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_37.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_38.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_39.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/GluGluHToZZTo4L_M130/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 992000 -->
-<!-- Generated number of events: 776000.0 -->
-<!-- Weighted number of events: 20914857.0276 -->
+<!-- Generated number of events: 992000.0 -->
+<!-- Weighted number of events: 26737018.1176 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130.xml
@@ -20,6 +20,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_27.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_28.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_29.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_3.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/pfcands/VBF_HToZZTo4L_M130/NTuples_MINIAOD_6.root"/>

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124.xml
@@ -30,6 +30,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_36.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_37.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_38.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_39.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_6.root"/>
@@ -37,5 +38,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M124/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 945000.0 -->
-<!-- Weighted number of events: 27672092.9776 -->
+<!-- Generated number of events: 994000.0 -->
+<!-- Weighted number of events: 29107175.0076 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126.xml
@@ -1,4 +1,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_1.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_13.root"/>
@@ -14,11 +15,14 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_24.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_26.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_27.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_28.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_29.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_3.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_30.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_31.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_32.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_33.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_34.root"/>
@@ -29,5 +33,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 957000 -->
-<!-- Generated number of events: 843000.0 -->
-<!-- Weighted number of events: 24006991.3054 -->
+<!-- Generated number of events: 957000.0 -->
+<!-- Weighted number of events: 27253642.9674 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130.xml
@@ -4,7 +4,9 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_14.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_15.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_16.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_17.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_18.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_19.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_2.root"/>
@@ -24,15 +26,17 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_32.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_33.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_34.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_35.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_36.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_37.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_38.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_39.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/GluGluHToZZTo4L_M130/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 992000 -->
-<!-- Generated number of events: 776000.0 -->
-<!-- Weighted number of events: 20914857.0276 -->
+<!-- Generated number of events: 992000.0 -->
+<!-- Weighted number of events: 26737018.1176 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130.xml
@@ -20,6 +20,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_27.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_28.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_29.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_3.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/stablegenparticles/VBF_HToZZTo4L_M130/NTuples_MINIAOD_6.root"/>

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124.xml
@@ -30,6 +30,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_36.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_37.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_38.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_39.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_6.root"/>
@@ -37,5 +38,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M124/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 994000 -->
-<!-- Generated number of events: 945000.0 -->
-<!-- Weighted number of events: 27672092.9776 -->
+<!-- Generated number of events: 994000.0 -->
+<!-- Weighted number of events: 29107175.0076 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126.xml
@@ -1,4 +1,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_1.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_10.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_11.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_13.root"/>
@@ -14,12 +15,14 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_22.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_23.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_24.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_25.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_26.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_27.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_28.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_29.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_3.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_30.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_31.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_32.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_33.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_34.root"/>
@@ -30,5 +33,5 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M126/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 957000 -->
-<!-- Generated number of events: 892000.0 -->
-<!-- Weighted number of events: 25403551.6054 -->
+<!-- Generated number of events: 957000.0 -->
+<!-- Weighted number of events: 27253642.9674 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130.xml
@@ -4,7 +4,9 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_12.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_13.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_14.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_15.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_16.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_17.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_18.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_19.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_2.root"/>
@@ -24,15 +26,17 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_32.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_33.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_34.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_35.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_36.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_37.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_38.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_39.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_6.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_7.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_8.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/GluGluHToZZTo4L_M130/NTuples_MINIAOD_9.root"/>
 <!-- Das number of events: 992000 -->
-<!-- Generated number of events: 776000.0 -->
-<!-- Weighted number of events: 20914857.0276 -->
+<!-- Generated number of events: 992000.0 -->
+<!-- Weighted number of events: 26737018.1176 -->

--- a/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130.xml
+++ b/Analyzer/datasets/UL18/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130.xml
@@ -20,6 +20,7 @@
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_27.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_28.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_29.root"/>
+<InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_3.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_4.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_5.root"/>
 <InputFile FileName="root://maite.iihe.ac.be:1094//pnfs/iihe/cms/store/user/anmalara/Tuples/UL18/Summer20/MINIAODv2/NTuples_v01/standard/VBF_HToZZTo4L_M130/NTuples_MINIAOD_6.root"/>

--- a/Generator/parallelize.py
+++ b/Generator/parallelize.py
@@ -1,0 +1,89 @@
+# Author: Arne Reimers & Andrea Malara
+import os, sys, time, glob
+import functools
+import subprocess
+from multiprocessing import Pool
+from printing_utils import blue, red
+
+def timeit(method):
+    @functools.wraps(method)
+    def timed(*args, **kw):
+        print(blue('--> Start of %r' %(method.__name__)))
+        ts = time.time()
+        result = method(*args, **kw)
+        te = time.time()
+        if 'log_time' in kw:
+            name = kw.get('log_name', method.__name__.upper())
+            kw['log_time'][name] = int((te - ts))
+        else:
+            print(blue('--> End of %r: %2.2f s' % (method.__name__, (te - ts))))
+        return result
+    return timed
+
+
+@timeit
+def MultiProcess(func,arglist,ncores=10):
+    global func_singlearg
+    def func_singlearg(kwargs):
+        return func(**kwargs)
+    pool = Pool(processes=int(ncores))
+    pool.imap_unordered(func_singlearg, arglist)
+    result = [i for i in pool.imap_unordered(func_singlearg, arglist)]
+    pool.close()
+    pool.join()
+    del globals()['func_singlearg']
+    return result
+
+def updateCouting(n_completed, n_jobs, time_to_sleep):
+    sys.stdout.write(blue('  --> %d of %d (%.1f%%) jobs done.\r' %(n_completed, n_jobs, round(float(n_completed)/float(n_jobs)*100, 1))))
+    sys.stdout.flush()
+    time.sleep(time_to_sleep)
+
+@timeit
+def parallelize(commands, getoutput=False, logfiles=[], ncores=10, cwd=False, niceness=10, remove_temp_files=True, time_to_sleep = 0.5):
+    processes, outputs, log_files = ({},{}, {})
+    n_running, n_completed, n_jobs = (0,0, len(commands))
+    is_log_given = not getoutput and len(logfiles)==n_jobs
+    for index, command in enumerate(commands):
+        cwd_ = command[0]  if cwd else None
+        proc = command[1:] if cwd else command
+        if isinstance(proc, list):
+            proc = ' '.join(proc)
+        if niceness is not None:
+            proc = 'nice -n %i %s' % (niceness, proc)
+        if getoutput:
+            if not isinstance(proc, str):
+                raise RuntimeError(red('getoutput supports only commands as string. Please fix this.'))
+            processes[index] = subprocess.Popen(proc, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd_)
+        else:
+            log_files[index] = open(list_logfiles[index] if is_log_given else os.path.join(cwd_ if cwd_ else '','parallelize_log_'+str(index)+'.txt'),'w')
+            processes[index] = subprocess.Popen(proc, stdout=log_files[index], stderr=log_files[index], shell=True, cwd=cwd_)
+        n_running += 1
+        while (n_running >= ncores):
+            for idx, proc in processes.items():
+                if proc.poll() != None:
+                    proc.wait()
+                    n_running -= 1
+                    n_completed += 1
+                    if getoutput:
+                        output = proc.communicate()
+                        outputs[idx] = {'stdout': output[0],'stderr': output[1],'returncode':str(proc.returncode)+' '+commands[idx]}
+                    else:
+                        log_files[idx].close()
+                    del processes[idx]
+            updateCouting(n_completed, n_jobs, time_to_sleep if len(commands) < 10000 else time_to_sleep/10000.)
+    while (n_completed < n_jobs):
+        for idx, proc in processes.items():
+            if proc.poll() != None:
+                n_completed += 1
+                if getoutput:
+                    output = proc.communicate()
+                    outputs[idx] = {'stdout': output[0],'stderr': output[1],'returncode':proc.returncode}
+                else:
+                    log_files[idx].close()
+                del processes[idx]
+        updateCouting(n_completed, n_jobs, time_to_sleep if len(commands) < 10000 else time_to_sleep/10000.)
+    print(blue('\nAll jobs completed'))
+    if remove_temp_files:
+        a = map(os.remove, [x.name for x in log_files.values()])
+    return outputs

--- a/Generator/parallelize.py
+++ b/Generator/parallelize.py
@@ -33,7 +33,7 @@ def timeit(method):
 
 
 @timeit
-def MultiProcess(func,arglist,ncores=10):
+def MultiProcess(func,arglist,ncores=8):
     global func_singlearg
     def func_singlearg(kwargs):
         return func(**kwargs)
@@ -46,7 +46,7 @@ def MultiProcess(func,arglist,ncores=10):
     return result
 
 @timeit
-def parallelize(commands, getoutput=False, logfiles=[], ncores=10, cwd=False, niceness=10, remove_temp_files=True, time_to_sleep = 0.5):
+def parallelize(commands, getoutput=False, logfiles=[], ncores=8, cwd=False, niceness=10, remove_temp_files=True, time_to_sleep = 0.5):
     def wait_for_process(sn):
         for idx, proc in sn.processes.items():
             if proc.poll() != None:
@@ -92,7 +92,6 @@ def parallelize(commands, getoutput=False, logfiles=[], ncores=10, cwd=False, ni
             wait_for_process(sn)
     while (sn.n_completed < sn.n_jobs):
         wait_for_process(sn)
-    print(blue('\nAll jobs completed'))
     if remove_temp_files:
         a = map(os.remove, [x.name for x in sn.log_files.values()])
     return sn.outputs


### PR DESCRIPTION
- Added new functions to parallelize:
 - `parallelize` is intended to substitute the `execute_commands_parallel` and `getoutput_commands_parallel` as includes all the previous features. It's more generic (see below) but doesn't support resubmission yet. For the moment, we will not modify the existing code.
   - inputs as long string of bash commands or list of strings
   - possibility to execute commands from different folders: the convention is to pass a list where the first element is the `path/to/folder` and the remaining elements are treated as the rest of the commands. Need the option `cwd` to be set as True
   - allow storing output to log files(passed as list of strings of filenames). As default, temporary log files are otherwise created and deleted afterwards. `remove_temp_files` can be set to false to keep the log files. Log files are not created if the `getoutput` option is true.
   - `getoutput` allows retrieving the output
 - Multiprocess: allow to spawn python functions in a parallelised way.
   - `arglist` is a list of dictionaries that will be interpreted as kwargs.
 - `execute_commands_parallel` can now submit commands from different folders
[ci skip]
